### PR TITLE
Update crossing-training.lic

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -403,11 +403,20 @@ class CrossingTraining
   end
 
   def research
+    if @settings.cyclic_research
+ 	    research_spell = @settings.crossing_cyclic_research_spells([])
+                       .min_by { |s| DRSkill.getxp(s) }
+      cyclic_research(research_spell)
+ 	  end
     if 'You cannot begin' == bput("research #{@researching} 300", 'You focus', 'You tentatively', 'You confidently', 'Abandoning the normal', 'You cannot begin')
       fput('research cancel')
       fput('research cancel')
       research
     end
+  end
+
+  def cyclic_research(research_spell)
+    cast_spell(@settings.research_training_spells({})[research_spell], research_spell)
   end
 
   def check_research


### PR DESCRIPTION
This adds the capability to designate cyclic spells during research.  It picks from the list provided based off lowest field xp.

For use in yaml:
crossing_cyclic_research_spells:
- Utility
- Warding

(obviously only list the ones that you have a cyclic spell for)

research_training_spells:
  Warding:
    abbrev: GHS
    cyclic: true
  Utility:
    abbrev: REZZ
    cyclic: true

(This is clearly an example of my setup)