### PR TITLE
Update crossing-training.lic

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -403,11 +403,20 @@ class CrossingTraining
   end
 
   def research
+    if @settings.cyclic_research
+      research_spell = @settings.crossing_cyclic_research_spells([])
+                       .min_by { |s| DRSkill.getxp(s) }
+      cyclic_research(research_spell)
+    end
     if 'You cannot begin' == bput("research #{@researching} 300", 'You focus', 'You tentatively', 'You confidently', 'Abandoning the normal', 'You cannot begin')
       fput('research cancel')
       fput('research cancel')
       research
     end
+  end
+
+  def cyclic_research(research_spell)
+    cast_spell(@settings.research_training_spells({})[research_spell], research_spell)
   end
 
   def check_research
@@ -489,7 +498,9 @@ class CrossingTraining
     fput('release care') if data['cyclic'] && DRSpells.active_spells['Caress of the Sun']
     fput('release bes') if data['cyclic'] && DRSpells.active_spells['Bear Strength']
     fput('release fg') if data['cyclic'] && DRSpells.active_spells['Faenella\'s Grace']
-
+    fput('release rezz') if data['cyclic'] && DRSpells.active_spells['Ressurection']
+    fput('release ghs') if data['cyclic'] && DRSpells.active_spells['Ghost Shroud']
+    
     bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if data['symbiosis']
     scaled_prep_mana = data['mana']
     if /Something in the area interferes/ =~ bput("prepare #{data['abbrev']} #{scaled_prep_mana}", @settings.prep_messages)


### PR DESCRIPTION
This adds the capability to designate cyclic spells during research.  It picks from the list provided based off lowest field xp.

For use in yaml:
crossing_cyclic_research_spells:
- Utility
- Warding

(obviously only list the ones that you have a cyclic spell for)

research_training_spells:
  Warding:
    abbrev: GHS
    cyclic: true
  Utility:
    abbrev: REZZ
    cyclic: true

(This is clearly an example of my setup)